### PR TITLE
Add run-length-encoding exercise

### DIFF
--- a/abaplint_exercises.json
+++ b/abaplint_exercises.json
@@ -327,7 +327,7 @@
       "ignorePatterns": [],
       "local": "^LCL_.+$",
       "exception": "^LCX_.+$",
-      "test": "^LTCL_.+$"
+      "test": "^LT.+$"
     },
     "local_testclass_location": true,
     "local_variable_names": false,

--- a/abaplint_solutions.json
+++ b/abaplint_solutions.json
@@ -323,7 +323,7 @@
       "ignorePatterns": [],
       "local": "^LCL_.+$",
       "exception": "^LCX_.+$",
-      "test": "^LTCL_.+$"
+      "test": "^LT.+$"
     },
     "local_testclass_location": true,
     "local_variable_names": false,

--- a/config.json
+++ b/config.json
@@ -108,6 +108,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2
+      },
+      {
+        "slug": "run-length-encoding",
+        "name": "Run Length Encoding",
+        "uuid": "18479071-0e8a-4ba6-8a32-fb2ee40cc94c",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
       }
     ]
   },

--- a/exercises/practice/run-length-encoding/.docs/instructions.md
+++ b/exercises/practice/run-length-encoding/.docs/instructions.md
@@ -1,0 +1,24 @@
+# Description
+
+Implement run-length encoding and decoding.
+
+Run-length encoding (RLE) is a simple form of data compression, where runs
+(consecutive data elements) are replaced by just one data value and count.
+
+For example we can represent the original 53 characters with only 13.
+
+```text
+"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"  ->  "12WB12W3B24WB"
+```
+
+RLE allows the original data to be perfectly reconstructed from
+the compressed data, which makes it a lossless data compression.
+
+```text
+"AABCCCDEEEE"  ->  "2AB3CD4E"  ->  "AABCCCDEEEE"
+```
+
+For simplicity, you can assume that the unencoded string will only contain
+the letters A through Z (either lower or upper case) and whitespace. This way
+data to be encoded will never contain any numbers and numbers inside data to
+be decoded always represent the count for the following character.

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,0 +1,13 @@
+{
+  "blurb": "Implement run-length encoding and decoding.",
+  "authors": ["pokrakam"],
+  "contributors": [
+  ],
+  "files": {
+    "solution": ["zcl_rle.clas.abap"],
+    "test": ["zcl_rle.clas.testclasses.abap"],
+    "example": [".meta/zcl_rle.clas.abap"]
+  },
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"
+}

--- a/exercises/practice/run-length-encoding/.meta/zcl_rle.clas.abap
+++ b/exercises/practice/run-length-encoding/.meta/zcl_rle.clas.abap
@@ -18,15 +18,14 @@ CLASS zcl_rle IMPLEMENTATION.
 
   METHOD encode.
 
-    DATA: str        TYPE string,
-          char       TYPE string,
+    DATA: char       TYPE string,
           duplicates TYPE string.
 
-    str = input.
+    DATA(str) = input.
 
     WHILE str IS NOT INITIAL.
 
-      FIND REGEX '([\w|\s])(\1*)(.*)' IN str SUBMATCHES char duplicates str.
+      FIND REGEX '([\w|\s])(\1*)(.*)' IN str SUBMATCHES char duplicates str  ##SUBRC_OK.
 
       IF duplicates IS NOT INITIAL.
         result = |{ result }{ strlen( duplicates ) + 1 }{ char }|.
@@ -41,15 +40,14 @@ CLASS zcl_rle IMPLEMENTATION.
 
   METHOD decode.
 
-    DATA: str  TYPE string,
-          char TYPE string,
+    DATA: char TYPE string,
           reps TYPE string.
 
-    str = input.
+    DATA(str) = input.
 
     WHILE str IS NOT INITIAL.
 
-      FIND REGEX '(\d*)([\w|\s])(.*)' IN str SUBMATCHES reps char str.
+      FIND REGEX '(\d*)([\w|\s])(.*)' IN str SUBMATCHES reps char str  ##SUBRC_OK.
 
       IF reps IS NOT INITIAL.
         result = |{ result }{ repeat( val = char occ = reps ) }|.

--- a/exercises/practice/run-length-encoding/.meta/zcl_rle.clas.abap
+++ b/exercises/practice/run-length-encoding/.meta/zcl_rle.clas.abap
@@ -1,0 +1,64 @@
+CLASS zcl_rle DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS encode IMPORTING input         TYPE string
+                   RETURNING VALUE(result) TYPE string.
+
+    METHODS decode IMPORTING input         TYPE string
+                   RETURNING VALUE(result) TYPE string.
+
+ENDCLASS.
+
+
+CLASS zcl_rle IMPLEMENTATION.
+
+  METHOD encode.
+
+    DATA: str        TYPE string,
+          char       TYPE string,
+          duplicates TYPE string.
+
+    str = input.
+
+    WHILE str IS NOT INITIAL.
+
+      FIND REGEX '([\w|\s])(\1*)(.*)' IN str SUBMATCHES char duplicates str.
+
+      IF duplicates IS NOT INITIAL.
+        result = |{ result }{ strlen( duplicates ) + 1 }{ char }|.
+      ELSE.
+        result = |{ result }{ char }|.
+      ENDIF.
+
+    ENDWHILE.
+
+  ENDMETHOD.
+
+
+  METHOD decode.
+
+    DATA: str  TYPE string,
+          char TYPE string,
+          reps TYPE string.
+
+    str = input.
+
+    WHILE str IS NOT INITIAL.
+
+      FIND REGEX '(\d*)([\w|\s])(.*)' IN str SUBMATCHES reps char str.
+
+      IF reps IS NOT INITIAL.
+        result = |{ result }{ repeat( val = char occ = reps ) }|.
+      ELSE.
+        result = |{ result }{ char }|.
+      ENDIF.
+
+    ENDWHILE.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/exercises/practice/run-length-encoding/zcl_rle.clas.abap
+++ b/exercises/practice/run-length-encoding/zcl_rle.clas.abap
@@ -1,0 +1,32 @@
+CLASS zcl_rle DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS encode IMPORTING input         TYPE string
+                   RETURNING VALUE(result) TYPE string.
+
+    METHODS decode IMPORTING input         TYPE string
+                   RETURNING VALUE(result) TYPE string.
+
+ENDCLASS.
+
+
+CLASS zcl_rle IMPLEMENTATION.
+
+  METHOD encode.
+
+    "Add solution here
+
+  ENDMETHOD.
+
+
+  METHOD decode.
+
+    "Add solution here
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/exercises/practice/run-length-encoding/zcl_rle.clas.testclasses.abap
+++ b/exercises/practice/run-length-encoding/zcl_rle.clas.testclasses.abap
@@ -3,7 +3,7 @@ CLASS ltc_encode DEFINITION FINAL FOR TESTING
   RISK LEVEL HARMLESS.
 
   PRIVATE SECTION.
-    DATA cut TYPE REF TO zcl_rle_solution.
+    DATA cut TYPE REF TO zcl_rle.
 
     METHODS setup.
 
@@ -19,7 +19,7 @@ ENDCLASS.
 CLASS ltc_encode IMPLEMENTATION.
 
   METHOD setup.
-    cut = NEW zcl_rle_solution( ).
+    cut = NEW zcl_rle( ).
   ENDMETHOD.
 
   METHOD empty_string.
@@ -60,7 +60,7 @@ CLASS ltc_decode DEFINITION FINAL FOR TESTING
   RISK LEVEL HARMLESS.
 
   PRIVATE SECTION.
-    DATA cut TYPE REF TO zcl_rle_solution.
+    DATA cut TYPE REF TO zcl_rle.
 
     METHODS setup.
 
@@ -77,7 +77,7 @@ ENDCLASS.
 CLASS ltc_decode IMPLEMENTATION.
 
   METHOD setup.
-    cut = NEW zcl_rle_solution( ).
+    cut = NEW zcl_rle( ).
   ENDMETHOD.
 
   METHOD empty_string.

--- a/exercises/practice/run-length-encoding/zcl_rle.clas.testclasses.abap
+++ b/exercises/practice/run-length-encoding/zcl_rle.clas.testclasses.abap
@@ -1,0 +1,118 @@
+CLASS ltc_encode DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    DATA cut TYPE REF TO zcl_rle_solution.
+
+    METHODS setup.
+
+    METHODS empty_string FOR TESTING RAISING cx_static_check.
+    METHODS no_repeat    FOR TESTING RAISING cx_static_check.
+    METHODS no_singles   FOR TESTING RAISING cx_static_check.
+    METHODS mixed_singles_and_repeats FOR TESTING RAISING cx_static_check.
+    METHODS mixed_and_spaces FOR TESTING RAISING cx_static_check.
+    METHODS lowercase        FOR TESTING RAISING cx_static_check.
+ENDCLASS.
+
+
+CLASS ltc_encode IMPLEMENTATION.
+
+  METHOD setup.
+    cut = NEW zcl_rle_solution( ).
+  ENDMETHOD.
+
+  METHOD empty_string.
+    cl_abap_unit_assert=>assert_equals( act = cut->encode( `` )
+                                        exp = `` ).
+  ENDMETHOD.
+
+  METHOD no_repeat.
+    cl_abap_unit_assert=>assert_equals( act = cut->encode( `XYZ` )
+                                        exp = `XYZ` ).
+  ENDMETHOD.
+
+  METHOD no_singles.
+    cl_abap_unit_assert=>assert_equals( act = cut->encode( `AABBBCCCC` )
+                                        exp = `2A3B4C` ).
+  ENDMETHOD.
+
+  METHOD mixed_singles_and_repeats.
+    cl_abap_unit_assert=>assert_equals( act = cut->encode( `WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB` )
+                                        exp = `12WB12W3B24WB` ).
+  ENDMETHOD.
+
+  METHOD mixed_and_spaces.
+    cl_abap_unit_assert=>assert_equals( act = cut->encode( `  hsqq qww  ` )
+                                        exp = `2 hs2q q2w2 ` ).
+  ENDMETHOD.
+
+  METHOD lowercase.
+    cl_abap_unit_assert=>assert_equals( act = cut->encode( `aabbbcccc` )
+                                        exp = `2a3b4c` ).
+  ENDMETHOD.
+
+ENDCLASS.
+
+
+CLASS ltc_decode DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    DATA cut TYPE REF TO zcl_rle_solution.
+
+    METHODS setup.
+
+    METHODS empty_string FOR TESTING RAISING cx_static_check.
+    METHODS no_repeat    FOR TESTING RAISING cx_static_check.
+    METHODS no_singles   FOR TESTING RAISING cx_static_check.
+    METHODS mixed_singles_and_repeats FOR TESTING RAISING cx_static_check.
+    METHODS mixed_and_spaces FOR TESTING RAISING cx_static_check.
+    METHODS lowercase        FOR TESTING RAISING cx_static_check.
+    METHODS encode_and_decode FOR TESTING RAISING cx_static_check.
+ENDCLASS.
+
+
+CLASS ltc_decode IMPLEMENTATION.
+
+  METHOD setup.
+    cut = NEW zcl_rle_solution( ).
+  ENDMETHOD.
+
+  METHOD empty_string.
+    cl_abap_unit_assert=>assert_equals( act = cut->decode( `` )
+                                        exp = `` ).
+  ENDMETHOD.
+
+  METHOD no_repeat.
+    cl_abap_unit_assert=>assert_equals( act = cut->decode( `XYZ` )
+                                        exp = `XYZ` ).
+  ENDMETHOD.
+
+  METHOD no_singles.
+    cl_abap_unit_assert=>assert_equals( act = cut->decode( `2A3B4C` )
+                                        exp = `AABBBCCCC` ).
+  ENDMETHOD.
+
+  METHOD mixed_singles_and_repeats.
+    cl_abap_unit_assert=>assert_equals( act = cut->decode( `12WB12W3B24WB` )
+                                        exp = `WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB` ).
+  ENDMETHOD.
+
+  METHOD mixed_and_spaces.
+    cl_abap_unit_assert=>assert_equals( act = cut->decode( `2 hs2q q2w2 ` )
+                                        exp = `  hsqq qww  ` ).
+  ENDMETHOD.
+
+  METHOD lowercase.
+    cl_abap_unit_assert=>assert_equals( act = cut->decode( `2a3b4c` )
+                                        exp = `aabbbcccc` ).
+  ENDMETHOD.
+
+  METHOD encode_and_decode.
+    cl_abap_unit_assert=>assert_equals( act = cut->decode( cut->encode( `zzz ZZ  zZ` ) )
+                                        exp = `zzz ZZ  zZ` ).
+  ENDMETHOD.
+
+ENDCLASS.


### PR DESCRIPTION
Also small update to linter to allow SAP-recommended test class naming for test class/double/helper - `ltc_` `ltd_` `lth_`