### PR TITLE
Added test for illegal characters in hamming distance strands.

### DIFF
--- a/exercises/practice/anagram/zcl_anagram.clas.testclasses.abap
+++ b/exercises/practice/anagram/zcl_anagram.clas.testclasses.abap
@@ -147,7 +147,7 @@ CLASS ltcl_anagram IMPLEMENTATION.
 
   METHOD test_case_insensitive_original.
     DATA(candidates) = VALUE string_table( ( |BANANA| ) ( |Banana| ) ( |banana| ) ).
-    DATA(exp_result) = VALUE string_table( ).
+    DATA(exp_result) = VALUE string_table( ( |BANANA| ) ( |Banana| ) ( |banana| ) ).
     cl_abap_unit_assert=>assert_equals(
       act = cut->anagram( input = 'BANANA' candidates = candidates )
       exp = exp_result ).

--- a/exercises/practice/hamming/zcl_hamming.clas.testclasses.abap
+++ b/exercises/practice/hamming/zcl_hamming.clas.testclasses.abap
@@ -11,6 +11,7 @@ CLASS ltcl_hamming DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FIN
     METHODS test_second_longer FOR TESTING RAISING cx_static_check.
     METHODS test_both_empty FOR TESTING RAISING cx_static_check.
     METHODS test_one_empty FOR TESTING RAISING cx_static_check.
+    METHODS test_illegal_character FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.
 
@@ -85,6 +86,16 @@ CLASS ltcl_hamming IMPLEMENTATION.
         cut->hamming_distance(
           first_strand  = ''
           second_strand = 'CGT' ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_parameter_invalid.
+    ENDTRY.
+  ENDMETHOD.
+  
+  METHOD test_illegal_character.
+    TRY.
+        cut->hamming_distance(
+          first_strand  = 'AABCT'
+          second_strand = 'AACTA' ).
         cl_abap_unit_assert=>fail( ).
       CATCH cx_parameter_invalid.
     ENDTRY.


### PR DESCRIPTION
Added test for illegal characters in hamming distance strands.

Reason: The exercise talks about what characters are allowed, but doesn't test it.