### PR TITLE
kindergarten-garden: fix invalid tests.toml

### DIFF
--- a/exercises/practice/kindergarten-garden/.meta/tests.toml
+++ b/exercises/practice/kindergarten-garden/.meta/tests.toml
@@ -1,52 +1,61 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# garden with single student
-"1fc316ed-17ab-4fba-88ef-3ae78296b692" = true
+[1fc316ed-17ab-4fba-88ef-3ae78296b692]
+description = "partial garden -> garden with single student"
 
-# different garden with single student
-"acd19dc1-2200-4317-bc2a-08f021276b40" = true
+[acd19dc1-2200-4317-bc2a-08f021276b40]
+description = "partial garden -> different garden with single student"
 
-# garden with two students
-"c376fcc8-349c-446c-94b0-903947315757" = true
+[c376fcc8-349c-446c-94b0-903947315757]
+description = "partial garden -> garden with two students"
 
-# second student's garden
-"2d620f45-9617-4924-9d27-751c80d17db9" = true
+[2d620f45-9617-4924-9d27-751c80d17db9]
+description = "partial garden -> multiple students for the same garden with three students -> second student's garden"
 
-# third student's garden
-"57712331-4896-4364-89f8-576421d69c44" = true
+[57712331-4896-4364-89f8-576421d69c44]
+description = "partial garden -> multiple students for the same garden with three students -> third student's garden"
 
-# for Alice, first student's garden
-"149b4290-58e1-40f2-8ae4-8b87c46e765b" = true
+[149b4290-58e1-40f2-8ae4-8b87c46e765b]
+description = "full garden -> for Alice, first student's garden"
 
-# for Bob, second student's garden
-"ba25dbbc-10bd-4a37-b18e-f89ecd098a5e" = true
+[ba25dbbc-10bd-4a37-b18e-f89ecd098a5e]
+description = "full garden -> for Bob, second student's garden"
 
-# for Charlie
-"566b621b-f18e-4c5f-873e-be30544b838c" = true
+[566b621b-f18e-4c5f-873e-be30544b838c]
+description = "full garden -> for Charlie"
 
-# for David
-"3ad3df57-dd98-46fc-9269-1877abf612aa" = true
+[3ad3df57-dd98-46fc-9269-1877abf612aa]
+description = "full garden -> for David"
 
-# for Eve
-"0f0a55d1-9710-46ed-a0eb-399ba8c72db2" = true
+[0f0a55d1-9710-46ed-a0eb-399ba8c72db2]
+description = "full garden -> for Eve"
 
-# for Fred
-"a7e80c90-b140-4ea1-aee3-f4625365c9a4" = true
+[a7e80c90-b140-4ea1-aee3-f4625365c9a4]
+description = "full garden -> for Fred"
 
-# for Ginny
-"9d94b273-2933-471b-86e8-dba68694c615" = true
+[9d94b273-2933-471b-86e8-dba68694c615]
+description = "full garden -> for Ginny"
 
-# for Harriet
-"f55bc6c2-ade8-4844-87c4-87196f1b7258" = true
+[f55bc6c2-ade8-4844-87c4-87196f1b7258]
+description = "full garden -> for Harriet"
 
-# for Ileana
-"759070a3-1bb1-4dd4-be2c-7cce1d7679ae" = true
+[759070a3-1bb1-4dd4-be2c-7cce1d7679ae]
+description = "full garden -> for Ileana"
 
-"for Joseph
-"78578123-2755-4d4a-9c7d-e985b8dda1c6" = true
+[78578123-2755-4d4a-9c7d-e985b8dda1c6]
+description = "full garden -> for Joseph"
 
-"for Kincaid, second to last student's garden
-"6bb66df7-f433-41ab-aec2-3ead6e99f65b" = true
+[6bb66df7-f433-41ab-aec2-3ead6e99f65b]
+description = "full garden -> for Kincaid, second to last student's garden"
 
-"for Larry, last student's garden
-"d7edec11-6488-418a-94e6-ed509e0fa7eb" = true
+[d7edec11-6488-418a-94e6-ed509e0fa7eb]
+description = "full garden -> for Larry, last student's garden"


### PR DESCRIPTION
This `tests.toml` contained invalid TOML syntax:

https://github.com/exercism/abap/blob/ceab0d5feb16322f54399ac7b4aabadc3a622cc8/exercises/practice/kindergarten-garden/.meta/tests.toml#L42-L52

which would cause `configlet sync` to produce an error.

The `tests.toml` was also using the [long-outdated format][1]. See the [specification for the expected format][2].

Regenerate the `tests.toml`, without changing which tests are stated to be implemented.

The only other `tests.toml` file in this repo (for state-of-tic-tac-toe) uses the correct format.

Fixes: #276

[1]: https://github.com/exercism/configlet/issues/198
[2]: https://exercism.org/docs/building/configlet/sync#h-tests

---

Ping @ErikSchierboom