### PR TITLE
Nucleotide Count: Fix syntax error

### DIFF
--- a/exercises/practice/nucleotide-count/.meta/zcl_nucleotide_count.clas.abap
+++ b/exercises/practice/nucleotide-count/.meta/zcl_nucleotide_count.clas.abap
@@ -9,12 +9,12 @@ CLASS zcl_nucleotide_count DEFINITION
         nucleotide TYPE c LENGTH 1,
         count      TYPE i,
       END OF count_by_nucleotide,
-      nucleotide_counts TYPE STANDARD TABLE OF count_by_nucleotide WITH KEY nucleotide.
+      ty_nucleotide_counts TYPE STANDARD TABLE OF count_by_nucleotide WITH KEY nucleotide.
     METHODS nucleotide_counts
       IMPORTING
         strand        TYPE string
       RETURNING
-        VALUE(result) TYPE nucleotide_counts
+        VALUE(result) TYPE ty_nucleotide_counts
       RAISING
         cx_parameter_invalid.
   PROTECTED SECTION.

--- a/exercises/practice/nucleotide-count/zcl_nucleotide_count.clas.abap
+++ b/exercises/practice/nucleotide-count/zcl_nucleotide_count.clas.abap
@@ -9,12 +9,12 @@ CLASS zcl_nucleotide_count DEFINITION
         nucleotide TYPE c LENGTH 1,
         count      TYPE i,
       END OF count_by_nucleotide,
-      nucleotide_counts TYPE STANDARD TABLE OF count_by_nucleotide WITH KEY nucleotide.
+      ty_nucleotide_counts TYPE STANDARD TABLE OF count_by_nucleotide WITH KEY nucleotide.
     METHODS nucleotide_counts
       IMPORTING
         strand        TYPE string
       RETURNING
-        VALUE(result) TYPE nucleotide_counts
+        VALUE(result) TYPE ty_nucleotide_counts
       RAISING
         cx_parameter_invalid.
   PROTECTED SECTION.

--- a/exercises/practice/nucleotide-count/zcl_nucleotide_count.clas.testclasses.abap
+++ b/exercises/practice/nucleotide-count/zcl_nucleotide_count.clas.testclasses.abap
@@ -23,7 +23,7 @@ CLASS ltcl_nucleotide_count IMPLEMENTATION.
   METHOD test_empty_strand.
     cl_abap_unit_assert=>assert_equals(
       act = cut->nucleotide_counts( '' )
-      exp = VALUE zcl_nucleotide_count=>nucleotide_counts(
+      exp = VALUE zcl_nucleotide_count=>ty_nucleotide_counts(
         ( nucleotide = 'A' count = 0 )
         ( nucleotide = 'C' count = 0 )
         ( nucleotide = 'G' count = 0 )
@@ -33,7 +33,7 @@ CLASS ltcl_nucleotide_count IMPLEMENTATION.
   METHOD test_single_character.
     cl_abap_unit_assert=>assert_equals(
       act = cut->nucleotide_counts( 'G' )
-      exp = VALUE zcl_nucleotide_count=>nucleotide_counts(
+      exp = VALUE zcl_nucleotide_count=>ty_nucleotide_counts(
         ( nucleotide = 'A' count = 0 )
         ( nucleotide = 'C' count = 0 )
         ( nucleotide = 'G' count = 1 )
@@ -43,7 +43,7 @@ CLASS ltcl_nucleotide_count IMPLEMENTATION.
   METHOD test_repeated_nucleotide.
     cl_abap_unit_assert=>assert_equals(
       act = cut->nucleotide_counts( 'GGGGGGG' )
-      exp = VALUE zcl_nucleotide_count=>nucleotide_counts(
+      exp = VALUE zcl_nucleotide_count=>ty_nucleotide_counts(
         ( nucleotide = 'A' count = 0 )
         ( nucleotide = 'C' count = 0 )
         ( nucleotide = 'G' count = 7 )
@@ -53,7 +53,7 @@ CLASS ltcl_nucleotide_count IMPLEMENTATION.
   METHOD test_multiple_nucleotides.
     cl_abap_unit_assert=>assert_equals(
       act = cut->nucleotide_counts( 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC' )
-      exp = VALUE zcl_nucleotide_count=>nucleotide_counts(
+      exp = VALUE zcl_nucleotide_count=>ty_nucleotide_counts(
         ( nucleotide = 'A' count = 20 )
         ( nucleotide = 'C' count = 12 )
         ( nucleotide = 'G' count = 17 )


### PR DESCRIPTION
Error when pulling into ABAP system. Types and methods must have distinct names.

<img width="584" height="66" alt="image" src="https://github.com/user-attachments/assets/633d2129-014b-4d51-8a9f-caa163847742" />
