### PR TITLE
Eluid's Eggs: Fix XML

### DIFF
--- a/exercises/practice/eliuds-eggs/package.devc.xml
+++ b/exercises/practice/eliuds-eggs/package.devc.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <DEVC>
-    <CTEXT>Exercism: Eliud's Eggs</CTEXT>
+    <CTEXT>Exercism: Eliud&apos;s Eggs</CTEXT>
    </DEVC>
   </asx:values>
  </asx:abap>

--- a/exercises/practice/eliuds-eggs/zcl_eliuds_eggs.clas.xml
+++ b/exercises/practice/eliuds-eggs/zcl_eliuds_eggs.clas.xml
@@ -5,7 +5,7 @@
    <VSEOCLASS>
     <CLSNAME>ZCL_ELIUDS_EGGS</CLSNAME>
     <LANGU>E</LANGU>
-    <DESCRIPT>Exercism: Eliud's Eggs</DESCRIPT>
+    <DESCRIPT>Exercism: Eliud&apos;s Eggs</DESCRIPT>
     <STATE>1</STATE>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>


### PR DESCRIPTION
ABAP escapes `'` as `&apos;` in XML. The change avoids diffs

<img width="1384" height="539" alt="image" src="https://github.com/user-attachments/assets/c3b8f4f6-0ff1-44eb-9b31-70a140043a7c" />
